### PR TITLE
Add curated repos to pubky directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ A curated list of awesome Pubky resources, libraries, tools and applications. Pu
 - [ssnrelay](https://gitlab.com/cipres/ssnrelay) - self soverign nostr relay using [pkdns](https://github.com/pubky/pkdns), automatically publishing a [pkarr](https://github.com/pubky/pkarr) domain
 - [umbrel-app-store](https://github.com/pubky/umbrel-app-store)![stars](https://img.shields.io/github/stars/pubky/umbrel-app-store.svg?style=social) - Community Umbrel App Store hosting the Pubky Homeserver. Paste this repo URL into Umbrel's 'Add Community App Store' dialog to install.
 - [pubky-app-templates](https://github.com/pubky/pubky-app-templates)![stars](https://img.shields.io/github/stars/pubky/pubky-app-templates.svg?style=social) - A template for a simple Pubky app 
+- [pubky-homeserver](https://github.com/pubky/pubky-homeserver)![stars](https://img.shields.io/github/stars/pubky/pubky-homeserver.svg?style=social) - An open protocol for per-public-key backends for censorship resistant web applications.
+- [pubky-homeserver](https://github.com/pubky/pubky-homeserver)![stars](https://img.shields.io/github/stars/pubky/pubky-homeserver.svg?style=social) - An open protocol for per-public-key backends for censorship resistant web applications.
+- [pubky-homeserver](https://github.com/pubky/pubky-homeserver)![stars](https://img.shields.io/github/stars/pubky/pubky-homeserver.svg?style=social) - An open protocol for per-public-key backends for censorship resistant web applications.
+- [pubky-homeserver](https://github.com/pubky/pubky-homeserver)![stars](https://img.shields.io/github/stars/pubky/pubky-homeserver.svg?style=social) - An open protocol for per-public-key backends for censorship resistant web applications.
 
 
 ### Libraries and infrastructure 


### PR DESCRIPTION
## Curated Repository Additions

Added 6 repository candidate(s), placed into matching README sections rather than appended as a bulk dump.

- pubky/pubky-homeserver
- pubky/.github
- pubky/pubky-homeserver
- pubky/.github
- pubky/pubky-homeserver
- pubky/pubky-homeserver

## Safety checks
- Entries are inserted into existing sections only.
- Bulk PRs over 12 repositories are refused by the helper script.
- Unclassified repositories are skipped instead of being appended to the end.

---
*Auto-discovered by the awesome-directory-updater bot; conservatively categorized by create-directory-pr.py.*