### PR TITLE
Add homeserver-dashboard to Pubky directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ A curated list of awesome Pubky resources, libraries, tools and applications. Pu
 - [Gtool](https://github.com/emanuelbertey/Gtool)![stars](https://img.shields.io/github/stars/emanuelbertey/Gtool.svg?style=social) - Godot game engine extension adding P2P support, decentralized DNS via PKARR, Nostr NIP support, and ring encryption
 - [iroh-discovery-cloudflare-worker](https://github.com/n0-computer/iroh-discovery-cloudflare-worker)![stars](https://img.shields.io/github/stars/n0-computer/iroh-discovery-cloudflare-worker.svg?style=social) - A Rust Cloudflare Worker that implements the pkarr relay format, by the n0/iroh team
 - [paykit-rs](https://github.com/pubky/paykit-rs)![stars](https://img.shields.io/github/stars/pubky/paykit-rs.svg?style=social) - Rust implementation of Paykit, a meta payment protocol using Pubky Core/PKARR for payment method discovery.
+- [homeserver-dashboard](https://github.com/pubky/homeserver-dashboard)![stars](https://img.shields.io/github/stars/pubky/homeserver-dashboard.svg?style=social) - Web-based admin dashboard for managing Pubky homeservers
 
 ### Research & Proposals
 - [atomicity](https://github.com/pubky/atomicity)![stars](https://img.shields.io/github/stars/pubky/atomicity.svg?style=social) - A peer-to-peer mutual credit system proposal combining Paykit, Pkarr, and Offset-like mutual credit for open credit issuance in any denomination


### PR DESCRIPTION
## Addition

- **pubky/homeserver-dashboard** (9★) — Web-based admin dashboard for managing Pubky homeservers, built with Next.js, TypeScript, and Shadcn UI

Added to the **Libraries and infrastructure** section. Official `pubky` org repo, actively maintained.

---

*Note: Also identified that `pubky-core` was renamed to `pubky-homeserver` (same repo). The README already lists it under its old name — updating those references would be a separate cleanup.*